### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/_posts/2016-05-11-generating-the-right-data.md
+++ b/_posts/2016-05-11-generating-the-right-data.md
@@ -363,8 +363,8 @@ def test_projects_end_after_they_started(project):
 There's a lot more to Hypothesis's data generation than this, but hopefully it gives you
 a flavour of the sort of things to try and the sort of things that are possible.
 
-It's worth having a read of [the documentation](http://hypothesis.readthedocs.io/en/latest/data.html)
-for this, and if you're still stuck then try asking [the community](http://hypothesis.readthedocs.io/en/latest/community.html)
+It's worth having a read of [the documentation](https://hypothesis.readthedocs.io/en/latest/data.html)
+for this, and if you're still stuck then try asking [the community](https://hypothesis.readthedocs.io/en/latest/community.html)
 for some help. We're pretty friendly.
 
 

--- a/_posts/2016-06-05-incremental-property-based-testing.md
+++ b/_posts/2016-06-05-incremental-property-based-testing.md
@@ -125,7 +125,7 @@ And then made the simplest change to our test to actually use it:
 Here, rather than providing the branch name as a default argument value, we
 are telling Hypothesis to come up with a branch name for us using the
 `just("new-branch")`
-[strategy](http://hypothesis.readthedocs.io/en/latest/data.html). This
+[strategy](https://hypothesis.readthedocs.io/en/latest/data.html). This
 strategy will always come up with `"new-branch"`, so it's actually no
 different from what we had before.
 

--- a/index.md
+++ b/index.md
@@ -59,7 +59,7 @@ Hypothesis integrates into your normal testing workflow. Getting started is as s
 writing some code using it - no new services to run, no new test runners to learn.
 
 Right now only the Python version of Hypothesis is production ready. To get started with it, check out
-[the documentation](https://hypothesis.readthedocs.org/en/latest/) or read some of the
+[the documentation](https://hypothesis.readthedocs.io/en/latest/) or read some of the
 [introductory articles here on this site](/articles/intro/).
 
 Once you've got started, or if you have a large number of people who want to get started all at once,

--- a/products/index.md
+++ b/products/index.md
@@ -25,7 +25,7 @@ To use Hypothesis for Python, simply add the *hypothesis* package to your requir
 or *pip install hypothesis* directly.
 
 The code is [available on Github](https://github.com/HypothesisWorks/hypothesis-python)
-and documentation is available [on readthedocs](http://hypothesis.readthedocs.io/).
+and documentation is available [on readthedocs](https://hypothesis.readthedocs.io/).
 
 ### Hypothesis Legacy Support
 

--- a/training/index.md
+++ b/training/index.md
@@ -10,7 +10,7 @@ Hypothesis **makes your testing less labor-intensive and more thorough**. You'll
 
 You don't *need* training to use Hypothesis, if you're not using Hypothesis already, why not just try it out first?
 
-Hypothesis has [extensive documentation](https://hypothesis.readthedocs.org/en/latest/), and a body of introductory articles are available [right here](/articles/intro/) to get you started. These resources and will help you and your team begin testing with Hypothesis in no time. Give it a spin!
+Hypothesis has [extensive documentation](https://hypothesis.readthedocs.io/en/latest/), and a body of introductory articles are available [right here](/articles/intro/) to get you started. These resources and will help you and your team begin testing with Hypothesis in no time. Give it a spin!
 
 Now that you *are* using Hypothesis, ask your team two questions:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
