### PR TITLE
Fix rendering of `lambda x: <unknown>`

### DIFF
--- a/_posts/2016-10-31-hypothesis-3.6.0-release.md
+++ b/_posts/2016-10-31-hypothesis-3.6.0-release.md
@@ -24,7 +24,7 @@ Apologies for any inconvenience this may have caused.
 This release reverts Hypothesis to its old pretty printing of lambda functions
 based on attempting to extract the source code rather than decompile the bytecode.
 This is unfortunately slightly inferior in some cases and may result in you
-occasionally seeing things like lambda x: <unknown> in statistics reports and
+occasionally seeing things like `lambda x: <unknown>` in statistics reports and
 strategy reprs.
 
 This removes the dependencies on uncompyle6, xdis and spark-parser.


### PR DESCRIPTION
If you look at the post in a web browser, the angle brackets have been interpreted as an HTML tag and promptly swallowed.

![screen shot 2016-10-31 at 20 21 17](https://cloud.githubusercontent.com/assets/301220/19870246/b38b7882-9fa7-11e6-9ef4-6c7c66b43fe2.png)

Rendering this as a `<code>` snippet should cause it to render correctly.

(I haven’t tested this because I don’t have a local Ruby installation, and the last time I tried to use Jekyll it was more hassle than it was worth. This feels like a fairly safe change.)