### PR TITLE
Add 'make build' and 'make serve' tasks using Docker for nicer local builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _site/
 .sass-cache/
+.docker
 
 # =========================
 # Operating System Files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.4-alpine3.6
+
+LABEL maintainer "Alex Chan <alex@alexwlchan.net>"
+LABEL description "Local build image for HypothesisWorks.github.io"
+
+COPY Gemfile .
+COPY Gemfile.lock .
+
+RUN apk update && \
+    apk add build-base make nodejs
+RUN bundle install
+
+WORKDIR /site
+
+ENTRYPOINT ["bundle", "exec", "jekyll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY Gemfile .
 COPY Gemfile.lock .
 
 RUN apk update && \
-    apk add build-base make nodejs
+    apk add build-base git make nodejs
 RUN bundle install
 
 WORKDIR /site

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+BUILD_IMAGE = hypothesisworks/hypothesisworks.github.io
+SERVE_CONTAINER = server
+
+ROOT = $(shell git rev-parse --show-toplevel)
+
+
+.docker/build: Dockerfile Gemfile Gemfile.lock
+	docker build --tag $(BUILD_IMAGE) .
+	mkdir -p .docker
+	touch .docker/build
+
+
+build: .docker/build
+	docker run --volume $(SRC):/site $(BUILD_IMAGE) build
+
+serve: .docker/build
+	@# Clean up old running containers
+	@docker stop $(SERVE_CONTAINER) >/dev/null 2>&1 || true
+	@docker rm $(SERVE_CONTAINER) >/dev/null 2>&1 || true
+
+	docker run \
+		--publish 5858:5858 \
+		--volume $(ROOT):/site \
+		--name $(SERVE_CONTAINER) \
+		--hostname $(SERVE_CONTAINER) \
+		--tty $(BUILD_IMAGE) \
+		serve --host $(SERVE_CONTAINER) --port 5858 --watch
+
+Gemfile.lock: Gemfile
+	docker run \
+		--volume $(ROOT):/site \
+		--workdir /site \
+		--tty $(shell cat Dockerfile | grep FROM | awk '{print $$2}') \
+		bundle lock --update
+
+
+.PHONY: build serve

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # README #
 
 This is the main hypothesis.works site. It is originally based off the [rifyll](https://github.com/itsrifat/rifyll) Jekyll template.
+
+## Getting started
+
+You need Git, make and Docker installed.
+
+To run a local copy of the site:
+
+```console
+$ git clone git@github.com:HypothesisWorks/HypothesisWorks.github.io.git
+$ make serve
+```
+
+The site should be running on <http://localhost:5858>.
+If you make changes to the source files, it will automatically update.
+
+To build a one-off set of static HTML files:
+
+```console
+$ make build
+```
+
+When you push to master, the site is automatically built and served by GitHub Pages.

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,16 @@ permalink: /articles/:title/
 highlighter: rouge
 
 #Other Global Configuration
-exclude: ['README.md']
+exclude:
+  - README.md
+  - LICENSE.md
+  - CNAME
+  - Gemfile
+  - Gemfile.lock
+  - Makefile
+  - provision.sh
+  - Vagrantfile
+  - Dockerfile
 
 excerpt_separator: <!--more-->
 


### PR DESCRIPTION
I want to write something for the site.
I want to preview it locally.
I don't want to install Ruby.

🤔 

This patch adds a Makefile with two commands:

```console
$ make build
$ make serve
```

which build the static HTML files, and run a local server on http://localhost:5858/, respectively. It builds and spins up appropriate Docker containers for running these tasks.

This is pulled from the work I've been doing [on my personal site](https://github.com/alexwlchan/alexwlchan.net). It's inspired by the Hypothesis build system (specifically, the way you get the right Python version installed for you when you run a Make task for the first time, but without replicating all of that machinery for Ruby).

I saw there was already some Vagrant config in the repo, but there weren't instructions, and running Vagrant on a underpowered laptop on hotel wifi would make me cry.