### PR TITLE
Link to data generation article from incremental property testing.

### DIFF
--- a/_posts/2016-06-05-incremental-property-based-testing.md
+++ b/_posts/2016-06-05-incremental-property-based-testing.md
@@ -254,7 +254,8 @@ toolkit can construct instances of non-primitive data types](
 {% post_url 2016-05-11-generating-the-right-data %}) like our `Repository`
 class.
 
-The next step would be to write a `repositories` strategy for our test:
+If we were to continue with a `repositories` strategy, our test would
+look something like this:
 
 ```python
     @given(repo=repositories(), branch_name=valid_branch_names())

--- a/_posts/2016-06-05-incremental-property-based-testing.md
+++ b/_posts/2016-06-05-incremental-property-based-testing.md
@@ -249,9 +249,12 @@ Going forward
 
 We stopped there, but we need not have. Just as the test should have held for
 any branch, it should also hold for any repository. We were just creating an
-empty repository because it was convenient for us.
+empty repository because it fit our focus here. [Hypothesis' data generation
+toolkit can construct instances of non-primitive data types](
+{% post_url 2016-05-11-generating-the-right-data %}) like our `Repository`
+class.
 
-If we were to continue, the test would have looked something like this:
+The next step would be to write a `repositories` strategy for our test:
 
 ```python
     @given(repo=repositories(), branch_name=valid_branch_names())


### PR DESCRIPTION
The end of "Evolving toward property-based testing with Hypothesis"
implies that a repositories strategy could refine the property under
test, but does not explain how to write it.  Readers who are linked
directly to this article won't know that "Generating the right data",
the next article in the recommended reading list, explains how to
write a strategy that instantiates arbitrary Python classes.

Explicitly state that Hypothesis can generate classes like Repository
and link to "Generating the right data" so interested readers can
learn how generate non-primitive data types.